### PR TITLE
Updates to support one file per signal type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+
+*.pyc
+blech_clust_jetstream_parallel1.sh
+blech_clust_jetstream_parallel.sh
+requirements/.DS_Store
+blech.dir

--- a/blech_channel_profile.py
+++ b/blech_channel_profile.py
@@ -40,7 +40,7 @@ try:
 	file_type = ['one file per signal type']
 except:
 	file_type = ['one file per channel']
-print("\tFile Type = " + file_type)
+print("\tFile Type = " + file_type[0])
 
 if file_type == ['one file per channel']:
 	amp_files = glob.glob(os.path.join(dir_path, "amp*dat"))

--- a/blech_channel_profile.py
+++ b/blech_channel_profile.py
@@ -31,38 +31,103 @@ if not os.path.exists(plot_dir):
     os.makedirs(plot_dir)
 
 # Get files to read
-amp_files = glob.glob(os.path.join(dir_path, "amp*dat"))
-amp_files = sorted(amp_files)
+
+#HANNAH CHANGE: ADDED TEST OF ONE FILE PER SIGNAL TYPE
+print("Testing File Type")
+file_list = os.listdir(dir_path)
+try:
+	file_list.index('auxiliary.dat')
+	file_type = ['one file per signal type']
+except:
+	file_type = ['one file per channel']
+print("\tFile Type = " + file_type)
+
+if file_type == ['one file per channel']:
+	amp_files = glob.glob(os.path.join(dir_path, "amp*dat"))
+	amp_files = sorted(amp_files)
+	digin_files = sorted(glob.glob(os.path.join(dir_path, "board-DI*")))
+elif file_type == ['one file per signal type']:
+	amp_files = glob.glob(os.path.join(dir_path, "amp*dat"))
+	digin_files = glob.glob(os.path.join(dir_path, "dig*dat"))
+	#Use info file for port list calculation
+	info_file = np.fromfile(dir_path + 'info.rhd', dtype = np.dtype('float32'))
+	sampling_rate = int(info_file[2])
+	# Read the time.dat file for use in separating out the one file per signal type data
+	num_recorded_samples = len(np.fromfile(dir_path + '/' + 'time.dat', dtype = np.dtype('float32')))
+	total_recording_time = num_recorded_samples/sampling_rate #In seconds
+
 if len(amp_files) < 1:
     raise Exception("Couldn't find amp*.dat files in dir" + "\n" +\
-            f"{dir_path}")
-digin_files = sorted(glob.glob(os.path.join(dir_path, "board-DIN*")))
+            f"{dir_path}")	
 
 # Plot files
+print("Now plotting ampilfier signals")
 downsample = 100
 row_lim = 8
-row_num = np.min((row_lim, len(amp_files)))
-col_num = int(np.ceil(len(amp_files)/row_num))
-
-
-fig,ax = plt.subplots(row_num, col_num, 
-        sharex=True, sharey=True, figsize = (15,10))
-for this_file, this_ax in tqdm(zip(amp_files, ax.flatten())):
-    data = np.fromfile(this_file, dtype = np.dtype('int16'))
-    this_ax.plot(data[::downsample])
-    this_ax.set_ylabel("_".join(os.path.basename(this_file)\
-            .split('.')[0].split('-')[1:]))
-plt.suptitle('Amplifier Data')
-fig.savefig(os.path.join(plot_dir, 'amplifier_data'))
-plt.close(fig)
-
-fig,ax = plt.subplots(len(digin_files),
-        sharex=True, sharey=True, figsize = (8,10))
-for this_file, this_ax in tqdm(zip(digin_files, ax.flatten())):
-    data = np.fromfile(this_file, dtype = np.dtype('uint16'))
-    this_ax.plot(data[::downsample])
-    this_ax.set_ylabel("_".join(os.path.basename(this_file)\
-            .split('.')[0].split('-')[1:]))
-plt.suptitle('DIGIN Data')
-fig.savefig(os.path.join(plot_dir, 'digin_data'))
-plt.close(fig)
+if file_type == ['one file per channel']:
+	row_num = np.min((row_lim, len(amp_files)))
+	col_num = int(np.ceil(len(amp_files)/row_num))
+	#Create plot
+	fig,ax = plt.subplots(row_num, col_num, 
+	        sharex=True, sharey=True, figsize = (15,10))
+	for this_file, this_ax in tqdm(zip(amp_files, ax.flatten())):
+	    data = np.fromfile(this_file, dtype = np.dtype('int16'))
+	    this_ax.plot(data[::downsample])
+	    this_ax.set_ylabel("_".join(os.path.basename(this_file)\
+	            .split('.')[0].split('-')[1:]))
+	plt.suptitle('Amplifier Data')
+	fig.savefig(os.path.join(plot_dir, 'amplifier_data'))
+	plt.close(fig)
+elif file_type == ['one file per signal type']:
+	amplifier_data = np.fromfile(amp_files[0], dtype = np.dtype('uint16'))
+	num_electrodes = int(len(amplifier_data)/num_recorded_samples)
+	amp_reshape = np.reshape(amplifier_data,(int(len(amplifier_data)/num_electrodes),num_electrodes)).T
+	row_num = np.min((row_lim, num_electrodes))
+	col_num = int(np.ceil(num_electrodes/row_num))
+	#Create plot
+	fig,ax = plt.subplots(row_num, col_num, 
+	        sharex=True, sharey=True, figsize = (15,10))
+	for e_i in tqdm(range(num_electrodes)):
+	    data = amp_reshape[e_i,:]
+	    ax_i = plt.subplot(row_num,col_num,e_i+1)
+	    ax_i.plot(data[::downsample])
+	    ax_i.set_ylabel('amp_' + str(e_i))
+	plt.suptitle('Amplifier Data')
+	fig.savefig(os.path.join(plot_dir, 'amplifier_data'))
+	plt.close(fig)
+	
+print("Now plotting digital input signals")
+if file_type == ['one file per channel']:
+	fig,ax = plt.subplots(len(digin_files),
+	        sharex=True, sharey=True, figsize = (8,10))
+	for this_file, this_ax in tqdm(zip(digin_files, ax.flatten())):
+	    data = np.fromfile(this_file, dtype = np.dtype('uint16'))
+	    this_ax.plot(data[::downsample])
+	    this_ax.set_ylabel("_".join(os.path.basename(this_file)\
+	            .split('.')[0].split('-')[1:]))
+	plt.suptitle('DIGIN Data')
+	fig.savefig(os.path.join(plot_dir, 'digin_data'))
+	plt.close(fig)
+elif file_type == ['one file per signal type']:
+	d_inputs = np.fromfile(digin_files[0], dtype=np.dtype('uint16'))
+	d_inputs_str = d_inputs.astype('str')
+	d_in_str_int = d_inputs_str.astype('int64')
+	d_diff = np.diff(d_in_str_int)
+	dig_in = list(np.unique(np.abs(d_diff)) - 1)
+	dig_in.remove(-1)
+	num_dig_ins = len(dig_in)
+	dig_inputs = np.zeros((num_dig_ins,len(d_inputs)))
+	for n_i in range(num_dig_ins):
+		start_ind = np.where(d_diff == n_i + 1)[0]
+		end_ind = np.where(d_diff == -1*(n_i + 1))[0]
+		for s_i in range(len(start_ind)):
+			dig_inputs[n_i,start_ind[s_i]:end_ind[s_i]] = 1
+	fig,ax = plt.subplots(num_dig_ins,1,
+	        sharex=True, sharey=True, figsize = (8,10))
+	for d_i in tqdm(range(num_dig_ins)):
+	    ax_i = plt.subplot(num_dig_ins,1,d_i+1)
+	    ax_i.plot(dig_inputs[d_i,::downsample])
+	    ax_i.set_ylabel('Dig_in_' + str(dig_in[d_i]))
+	plt.suptitle('DIGIN Data')
+	fig.savefig(os.path.join(plot_dir, 'digin_data'))
+	plt.close(fig)

--- a/blech_clust.py
+++ b/blech_clust.py
@@ -42,6 +42,9 @@ if len(json_path) == 0:
             '== Exiting ==')
     exit()
 
+with open(json_path[0], 'r') as params_file:
+    info_dict = json.load(params_file)
+
 # Get the names of all files in this directory
 file_list = os.listdir('./')
 
@@ -143,52 +146,49 @@ check_str = f'Amplifier files: {electrodes_list} \nSampling rate: {sampling_rate
            f'\nDigital input files: {dig_in_list} \n ---------- \n \n'
 print(check_str)
 
+ports = info_dict['ports']
+
 if file_type == ['one file per channel']:
-	# Get the amplifier ports used
-	ports = list(np.unique(np.array([f[4] for f in file_list if f[:4] == 'amp-'])))
-	# Sort the ports in alphabetical order
-	ports.sort()
-	
-	## Pull out the digital input channels used, and convert them to integers
-	#dig_in = list(set(f[11:13] for f in file_list if f[:9] == 'board-DIN'))
-	#for i in range(len(dig_in)):
-	#	dig_in[i] = int(dig_in[i][0])
-	#dig_in.sort()
-	
-	# Read dig-in data
-	# Pull out the digital input channels used, 
-	# and convert them to integers
-	dig_in_files = [x for x in file_list if "DI" in x]
-	dig_in = [x.split('-')[-1].split('.')[0] for x in dig_in_files]
-	dig_in = sorted([int(x) for x in dig_in])
+    print("\tOne file per CHANNEL Detected")
+    ## Get the amplifier ports used
+    #ports = list(np.unique(np.array([f[4] for f in file_list if f[:4] == 'amp-'])))
+    ## Sort the ports in alphabetical order
+    #ports.sort()
+
+    # Read dig-in data
+    # Pull out the digital input channels used, 
+    # and convert them to integers
+    dig_in_files = [x for x in file_list if "DI" in x]
+    dig_in = [x.split('-')[-1].split('.')[0] for x in dig_in_files]
+    dig_in = sorted([int(x) for x in dig_in])
+
 elif file_type == ['one file per signal type']:
-	print("\tSingle Amplifier File Detected")
-	#Import amplifier data and calculate the number of electrodes
-	print("\t\tCalculating Number of Ports")
-	amplifier_data = np.fromfile(dir_name + '/' + electrodes_list[0], dtype = np.dtype('uint16'))
-	num_electrodes = int(len(amplifier_data)/num_recorded_samples)
-	ports = list(np.arange(num_electrodes))
-	del amplifier_data, num_electrodes
-	#Import digin data and calculate the number of digins
-	print("\t\tCalculating Number of Dig-Ins")
-	dig_in_data = np.fromfile(dir_name + '/' + dig_in_list[0], dtype=np.dtype('uint16'))
-	d_inputs_str = dig_in_data.astype('str')
-	del dig_in_data
-	d_in_str_int = d_inputs_str.astype('int64')
-	del d_inputs_str
-	d_diff = np.diff(d_in_str_int)
-	del d_in_str_int
-	dig_in = list(np.unique(np.abs(d_diff)) - 1)
-	dig_in.remove(-1)
-	del d_diff
+
+    print("\tOne file per SIGNAL Detected")
+    #Import amplifier data and calculate the number of electrodes
+    #print("\t\tCalculating Number of Ports")
+    #amplifier_data = np.fromfile(dir_name + '/' + electrodes_list[0], dtype = np.dtype('uint16'))
+    #num_electrodes = int(len(amplifier_data)/num_recorded_samples)
+    #ports = list(np.arange(num_electrodes))
+    #del amplifier_data, num_electrodes
+    #Import digin data and calculate the number of digins
+    #print("\t\tCalculating Number of Dig-Ins")
+    #dig_in_data = np.fromfile(dir_name + '/' + dig_in_list[0], dtype=np.dtype('uint16'))
+    #d_inputs_str = dig_in_data.astype('str')
+    #del dig_in_data
+    #d_in_str_int = d_inputs_str.astype('int64')
+    #del d_inputs_str
+    #d_diff = np.diff(d_in_str_int)
+    #del d_in_str_int
+    #dig_in = list(np.unique(np.abs(d_diff)) - 1)
+    #dig_in.remove(-1)
+    #del d_diff
+    dig_in = np.arange(info_dict['dig_ins']['count'])
 
 check_str = f'ports used: {ports} \n sampling rate: {sampling_rate} Hz'\
             f'\n digital inputs on intan board: {dig_in}'
 
 print(check_str)
-
-with open(json_path[0], 'r') as params_file:
-    info_dict = json.load(params_file)
 
 all_car_group_vals = []
 for region_name, region_elecs in info_dict['electrode_layout'].items():

--- a/blech_common_avg_reference.py
+++ b/blech_common_avg_reference.py
@@ -18,7 +18,7 @@ if sys.argv[1] != '':
     if dir_name[-1] != '/':
         dir_name += '/'
 else:
-    dir_name = easygui.diropenbox('Please select data directory')
+    dir_name = easygui.diropenbox('Please select data directory') + '/'
 
 print(f'Processing : {dir_name}')
 
@@ -35,24 +35,11 @@ for files in file_list:
 # Open the hdf5 file
 hf5 = tables.open_file(hdf5_name, 'r+')
 
-# Get the names of all files in this directory
-file_list = os.listdir('./')
-
-# Get the Intan amplifier ports used in the recordings
-ports = list(set(f[4] for f in file_list if f[:3] == 'amp'))
-# Sort the ports in alphabetical order
-ports.sort()
-
-# Count the number of electrodes on one of the ports 
-# (assume all ports have equal number of electrodes)
-num_electrodes = [int(f[-7:-4]) for f in file_list if f[:3] == 'amp']
-num_electrodes = np.max(num_electrodes) + 1
-
 # Read CAR groups from info file
 # Every region is a separate group, multiple ports under single region is a separate group,
 # emg is a separate group
 dir_basename = os.path.basename(dir_name[:-1])
-json_path = glob.glob(os.path.join(dir_name, dir_basename + '.info'))[0]
+json_path = glob.glob(os.path.join(dir_name + dir_basename + '.info'))[0]
 with open(json_path, 'r') as params_file:
     info_dict = json.load(params_file)
 

--- a/blech_exp_info.py
+++ b/blech_exp_info.py
@@ -140,7 +140,10 @@ else:
     if use_csv_str in ['n','no']: 
         layout_frame = pd.DataFrame()
         layout_frame['filename'] = electrode_files
-        layout_frame['port'] = ports
+        if not isinstance(ports, str):
+            layout_frame['port'] = ports[0]
+        else:
+            layout_frame['port'] = ports
         layout_frame['electrode_num'] = electrode_num_list
         layout_frame['electrode_ind'] = layout_frame.index
         layout_frame['CAR_group'] = pd.Series()
@@ -200,16 +203,16 @@ else:
         nums = re.findall('[0-9]+',x)
         return sum([x.isdigit() for x in nums]) == len(nums)
 
-	#Calculate number of deliveries from recorded data
+    #Calculate number of deliveries from recorded data
     if file_type == ['one file per channel']:
         dig_in_trials = []
         num_dig_ins = len(dig_in_list)
         for i in range(num_dig_ins):
-			      dig_inputs = np.array(np.fromfile(dir_path + dig_in_list[i], dtype = np.dtype('uint16')))
-			      d_diff = np.diff(dig_inputs)
-			      start_ind = np.where(d_diff == 1)[0]
-			      dig_in_trials.append(int(len(start_ind)))
-		
+            dig_inputs = np.array(np.fromfile(dir_path + dig_in_list[i], dtype = np.dtype('uint16')))
+            d_diff = np.diff(dig_inputs)
+            start_ind = np.where(d_diff == 1)[0]
+            dig_in_trials.append(int(len(start_ind)))
+
     elif file_type == ['one file per signal type']:
         d_inputs = np.fromfile(dir_path + dig_in_list[0], dtype=np.dtype('uint16'))
         d_inputs_str = d_inputs.astype('str')

--- a/blech_exp_info.py
+++ b/blech_exp_info.py
@@ -28,6 +28,7 @@ import itertools as it
 import argparse
 import pdb
 import pandas as pd
+#When running in Spyder, throws an error, so cd to utils folder and then back out
 from utils.blech_utils import entry_checker
 
 
@@ -46,7 +47,7 @@ if args.dir_name:
     if dir_path[-1] != '/':
         dir_path += '/'
 else:
-    dir_path = easygui.diropenbox(msg = 'Please select data directory')
+    dir_path = easygui.diropenbox(msg = 'Please select data directory') + '/'
 
 dir_name = os.path.basename(dir_path[:-1])
 
@@ -55,8 +56,8 @@ splits = dir_name.split("_")
 this_dict = {
         "name" : splits[0],
         "exp_type" : splits[1],
-        "date": splits[2],
-        "timestamp" : splits[3]}
+        "date": splits[-2],
+        "timestamp" : splits[-1]}
 
 ##################################################
 ## Brain Regions and Electrode Layout
@@ -85,12 +86,41 @@ else:
         regions = [x.lower() for x in re.findall('[A-Za-z]+',region_str)]
     else:
         exit()
-
+	
     # Find all ports used
     file_list = os.listdir(dir_path)
-    ports = list(set(f[4] for f in file_list if f[:3] == 'amp'))
-    # Sort the ports in alphabetical order
-    ports.sort()
+    try:
+        file_list.index('auxiliary.dat')
+        file_type = ['one file per signal type']
+    except:
+        file_type = ['one file per channel']
+	
+	
+    if file_type == ['one file per signal type']:
+        electrodes_list = ['amplifier.dat']
+        dig_in_list = ['digitalin.dat']
+    elif file_type == ['one file per channel']:
+        electrodes_list = [name for name in file_list if name.startswith('amp-')]
+        dig_in_list = [name for name in file_list if name.startswith('board-DI')]
+	
+    if file_type == ['one file per channel']:
+        electrode_files = sorted(electrodes_list)
+        ports = [x.split('-')[1] for x in electrode_files]
+        electrode_num_list = [x.split('-')[2].split('.')[0] \
+                        for x in electrode_files]
+		# Sort the ports in alphabetical order
+        ports.sort()
+    elif file_type == ['one file per signal type']:
+        print("\tSingle Amplifier File Detected")
+		#Import amplifier data and calculate the number of electrodes
+        print("\t\tCalculating Number of Ports")
+        num_recorded_samples = len(np.fromfile(dir_path + 'time.dat', dtype = np.dtype('float32')))
+        amplifier_data = np.fromfile(dir_path + 'amplifier.dat', dtype = np.dtype('uint16'))
+        num_electrodes = int(len(amplifier_data)/num_recorded_samples)
+        electrode_files = ['amplifier.dat' for i in range(num_electrodes)]
+        ports = ['A']
+        electrode_num_list = list(np.arange(num_electrodes))
+        del amplifier_data, num_electrodes
 
     # Write out file and ask user to define regions in file
     layout_file_path = os.path.join(dir_path, dir_name + "_electrode_layout.csv")
@@ -108,13 +138,9 @@ else:
         use_csv_str = 'n'
 
     if use_csv_str in ['n','no']: 
-        electrode_files = sorted([x for x in file_list if 'amp' in x])
-        port_list = [x.split('-')[1] for x in electrode_files]
-        electrode_num_list = [x.split('-')[2].split('.')[0] \
-                        for x in electrode_files]
         layout_frame = pd.DataFrame()
         layout_frame['filename'] = electrode_files
-        layout_frame['port'] = port_list
+        layout_frame['port'] = ports
         layout_frame['electrode_num'] = electrode_num_list
         layout_frame['electrode_ind'] = layout_frame.index
         layout_frame['CAR_group'] = pd.Series()
@@ -174,6 +200,34 @@ else:
         nums = re.findall('[0-9]+',x)
         return sum([x.isdigit() for x in nums]) == len(nums)
 
+	#Calculate number of deliveries from recorded data
+    if file_type == ['one file per channel']:
+        dig_in_trials = []
+        num_dig_ins = len(dig_in_list)
+        for i in range(num_dig_ins):
+			      dig_inputs = np.array(np.fromfile(dir_path + dig_in_list[i], dtype = np.dtype('uint16')))
+			      d_diff = np.diff(dig_inputs)
+			      start_ind = np.where(d_diff == 1)[0]
+			      dig_in_trials.append(int(len(start_ind)))
+		
+    elif file_type == ['one file per signal type']:
+        d_inputs = np.fromfile(dir_path + dig_in_list[0], dtype=np.dtype('uint16'))
+        d_inputs_str = d_inputs.astype('str')
+        del d_inputs
+        d_in_str_int = d_inputs_str.astype('int64')
+        del d_inputs_str
+        d_diff = np.diff(d_in_str_int)
+        del d_in_str_int
+        dig_in = list(np.unique(np.abs(d_diff)) - 1)
+        dig_in.remove(-1)
+        num_dig_ins = len(dig_in)
+        dig_in_trials = []
+        for n_i in range(num_dig_ins):
+                start_ind = np.where(d_diff == n_i + 1)[0]
+                dig_in_trials.append(int(len(start_ind)))
+	
+	#Ask for user input of which line index the dig in came from
+    print("A total of " + str(num_dig_ins) + " were found. Please provide the indices.")
     taste_dig_in_str, continue_bool = entry_checker(\
             msg = ' Taste dig_ins used (IN ORDER, anything separated)  :: ',
             check_func = count_check,
@@ -189,15 +243,15 @@ else:
         return len(x.split(',')) == len(taste_digins)
 
     # Trials per taste
-    dig_in_trials_str, continue_bool = entry_checker(\
-            msg = ' Trials per dig-in (IN ORDER, anything separated)  :: ',
-            check_func = count_check,
-            fail_response = 'Please enter integers only, and as many as dig-ins')
-    if continue_bool:
-        nums = re.findall('[0-9]+',dig_in_trials_str)
-        dig_in_trials = [int(x) for x in nums]
-    else:
-        exit()
+    #dig_in_trials_str, continue_bool = entry_checker(\
+    #        msg = ' Trials per dig-in (IN ORDER, anything separated)  :: ',
+    #        check_func = count_check,
+    #        fail_response = 'Please enter integers only, and as many as dig-ins')
+    #if continue_bool:
+    #    nums = re.findall('[0-9]+',dig_in_trials_str)
+    #    dig_in_trials = [int(x) for x in nums]
+    #else:
+    #    exit()
 
     def taste_check(x):
         global taste_digins

--- a/blech_process.py
+++ b/blech_process.py
@@ -103,7 +103,7 @@ def gen_datashader_plot(
             x,
             downsample=False,
             threshold=threshold,
-            dir_name="datashader_temp_el" + str(electrode_num))
+            dir_name= "Plots/" + "datashader_temp_el" + str(electrode_num))
 
     ax.set_xlabel('Sample ({:d} samples per ms)'.
                   format(int(sampling_rate/1000)))

--- a/utils/read_file.py
+++ b/utils/read_file.py
@@ -5,7 +5,7 @@ import numpy as np
 import tqdm
 
 #todo: Separate functions for electrode, EMG, and dig-in channels
-def read_digins(hdf5_name, dig_in): 
+def read_digins(hdf5_name, dig_in, dig_in_list): 
         hf5 = tables.open_file(hdf5_name, 'r+')
         # Read digital inputs, and append to the respective hdf5 arrays
         print('Reading dig-ins')
@@ -13,12 +13,36 @@ def read_digins(hdf5_name, dig_in):
         for i in dig_in:
                 dig_inputs = hf5.create_earray(\
                         '/digital_in', 'dig_in_%i' % i, atom, (0,))
-        for i in tqdm.tqdm(dig_in):
-                inputs = np.fromfile('board-DIN-%02d'%i + '.dat', 
+                dig_name = [d_n for d_n in dig_in_list if int(d_n.split('.')[-2][-2:]) == i]
+                inputs = np.fromfile(dig_name[0], 
                                         dtype = np.dtype('uint16'))
                 exec("hf5.root.digital_in.dig_in_"+str(i)+".append(inputs[:])")
         hf5.flush()
         hf5.close()
+		
+#todo: Separate functions for electrode, EMG, and dig-in channels
+def read_digins_single_file(hdf5_name, dig_in, dig_in_list): 
+	num_dig_ins = len(dig_in)
+	hf5 = tables.open_file(hdf5_name, 'r+')
+	# Read digital inputs, and append to the respective hdf5 arrays
+	print('Reading dig-ins')
+	atom = tables.IntAtom()
+	for i in dig_in:
+		dig_inputs = hf5.create_earray('/digital_in', 'dig_in_%i' % i, atom, (0,))
+	d_inputs = np.fromfile(dig_in_list[0], dtype=np.dtype('uint16'))
+	d_inputs_str = d_inputs.astype('str')
+	d_in_str_int = d_inputs_str.astype('int64')
+	d_diff = np.diff(d_in_str_int)
+	dig_inputs = np.zeros((num_dig_ins,len(d_inputs)))
+	for n_i in range(num_dig_ins):
+		start_ind = np.where(d_diff == n_i + 1)[0]
+		end_ind = np.where(d_diff == -1*(n_i + 1))[0]
+		for s_i in range(len(start_ind)):
+			dig_inputs[n_i,start_ind[s_i]:end_ind[s_i]] = 1
+	for i in tqdm.tqdm(range(num_dig_ins)):		
+		exec("hf5.root.digital_in.dig_in_"+str(i)+".append(dig_inputs[i,:])")
+	hf5.flush()
+	hf5.close()
 
 # TODO: Remove exec statements throughout file
 def read_emg_channels(hdf5_name, electrode_layout_frame):
@@ -66,3 +90,32 @@ def read_electrode_channels(hdf5_name, electrode_layout_frame):
                     "append(data[:])")
             hf5.flush()
     hf5.close()
+	
+def read_electrode_emg_channels_single_file(hdf5_name, electrode_layout_frame, electrodes_list, num_recorded_samples, emg_channels):
+    # Read EMG data from amplifier channels
+	hf5 = tables.open_file(hdf5_name, 'r+')
+	atom = tables.IntAtom()
+	amplifier_data = np.fromfile(electrodes_list[0], dtype = np.dtype('int16'))
+	num_electrodes = int(len(amplifier_data)/num_recorded_samples)
+	amp_reshape = np.reshape(amplifier_data,(int(len(amplifier_data)/num_electrodes),num_electrodes)).T
+	for num,row in tqdm.tqdm(electrode_layout_frame.iterrows()):
+        # Loading should use file name 
+        # but writing should use channel ind so that channels from 
+        # multiple boards are written into a monotonic sequence
+		emg_bool = 'emg' not in row.CAR_group.lower()
+		none_bool = row.CAR_group.lower() not in ['none','na']
+		if emg_bool and none_bool:
+			print(f'Reading : {row.filename, row.CAR_group}')
+			port = row.port
+			channel_ind = row.electrode_ind
+            #el = hf5.create_earray('/raw_emg', f'emg{emg_counter:02}', atom, (0,))
+            # Label raw_emg with electrode_ind so it's more easily identifiable
+			el = hf5.create_earray('/raw', f'electrode{channel_ind:02}', atom, (0,))
+			exec(f"hf5.root.raw.electrode{channel_ind:02}.append(amp_reshape[num,:])")
+			hf5.flush()
+		elif not(emg_bool) and none_bool:
+			port = row.port
+			channel_ind = row.electrode_ind
+			el = hf5.create_earray('/raw_emg', f'emg{channel_ind:02}', atom, (0,))
+			exec(f"hf5.root.raw_emg.emg{channel_ind:02}.append(amp_reshape[num,:])")
+	hf5.close()


### PR DESCRIPTION
blech_clust.py:
- added a line to grab the file path in the beginning, rather than assuming the file is on the desktop
- updated easygui dir_name to include '/' at the end to match $DIR input format
- added a test of whether data is in "one file per signal type" or "one file per channel" format
- updated port/electrode/emg/dig-in .dat file list imports to reflect the data storage type
- updated data imports and storage to .h5 file to reflect the data storage type

blech_exp_info.py:
- updated easygui dir_name to include '/' at the end to match $DIR input format
- updated dictionary date and timestamp data pulling to be more realistic
- added a test of whether data is in "one file per signal type" or "one file per channel" format
- updated port/electrode/emg/dig-in .dat file list imports to reflect the data storage type
- updated dig in delivery number to come from the data, rather than user input (more reliable)

read_file.py:
- updated read_digins() to support new software naming convention
- added read_digins_single_file() to support import and storage of digins from single file format
- added read_electrode_emg_channels_single_file() to support import and storage of electrodes and emg channels from single file format