### PR TITLE
Fix digin numbering

### DIFF
--- a/blech_clust.py
+++ b/blech_clust.py
@@ -98,13 +98,13 @@ print('Created dirs in data folder')
 # Get lists of amplifier and digital input files
 if file_type == ['one file per signal type']:
     electrodes_list = ['amplifier.dat']
-    dig_in_list = ['digitalin.dat']
+    dig_in_file_list = ['digitalin.dat']
 elif file_type == ['one file per channel']:
     electrodes_list = [name for name in file_list if name.startswith('amp-')]
-    dig_in_list = [name for name in file_list if name.startswith('board-DI')]
+    dig_in_file_list = [name for name in file_list if name.startswith('board-DI')]
 
 electrodes_list = sorted(electrodes_list)
-dig_in_list = sorted(dig_in_list)
+dig_in_file_list = sorted(dig_in_file_list)
 
 # Use info file for port list calculation
 info_file = np.fromfile(dir_name + '/info.rhd', dtype=np.dtype('float32'))
@@ -117,7 +117,7 @@ num_recorded_samples = len(np.fromfile(
 total_recording_time = num_recorded_samples/sampling_rate  # In seconds
 
 check_str = f'Amplifier files: {electrodes_list} \nSampling rate: {sampling_rate} Hz'\
-    f'\nDigital input files: {dig_in_list} \n ---------- \n \n'
+    f'\nDigital input files: {dig_in_file_list} \n ---------- \n \n'
 print(check_str)
 
 ports = info_dict['ports']
@@ -128,16 +128,16 @@ if file_type == ['one file per channel']:
     # Read dig-in data
     # Pull out the digital input channels used,
     # and convert them to integers
-    dig_in = [x.split('-')[-1].split('.')[0] for x in dig_in_list]
-    dig_in = sorted([int(x) for x in dig_in])
+    dig_in_int = [x.split('-')[-1].split('.')[0] for x in dig_in_file_list]
+    dig_in_int = sorted([int(x) for x in dig_in_int])
 
 elif file_type == ['one file per signal type']:
 
     print("\tOne file per SIGNAL Detected")
-    dig_in = np.arange(info_dict['dig_ins']['count'])
+    dig_in_int = np.arange(info_dict['dig_ins']['count'])
 
 check_str = f'ports used: {ports} \n sampling rate: {sampling_rate} Hz'\
-            f'\n digital inputs on intan board: {dig_in}'
+            f'\n digital inputs on intan board: {dig_in_int}'
 
 print(check_str)
 
@@ -161,12 +161,12 @@ electrode_layout_frame = pd.read_csv(layout_path)
 
 # Read data files, and append to electrode arrays
 if file_type == ['one file per channel']:
-    read_file.read_digins(hdf5_name, dig_in, dig_in_list)
+    read_file.read_digins(hdf5_name, dig_in_int, dig_in_file_list)
     read_file.read_electrode_channels(hdf5_name, electrode_layout_frame)
     if len(emg_channels) > 0:
         read_file.read_emg_channels(hdf5_name, electrode_layout_frame)
 elif file_type == ['one file per signal type']:
-    read_file.read_digins_single_file(hdf5_name, dig_in, dig_in_list)
+    read_file.read_digins_single_file(hdf5_name, dig_in_int, dig_in_file_list)
     # This next line takes care of both electrodes and emgs
     read_file.read_electrode_emg_channels_single_file(
         hdf5_name, electrode_layout_frame, electrodes_list, num_recorded_samples, emg_channels)

--- a/blech_exp_info.py
+++ b/blech_exp_info.py
@@ -192,6 +192,11 @@ else:
                 dir_path + dig_in_list[i], dtype=np.dtype('uint16')))
             d_diff = np.diff(dig_inputs)
             start_ind = np.where(d_diff == 1)[0]
+            if len(start_ind) == 0:
+                print(f"== No deliveries detected for {dig_in_list[i]} ==")
+                print("== blech_clust is sad and can't work under these conditions ==")
+                print(f"== Please delete {dig_in_list[i]} and try again ==")
+                exit()
             dig_in_trials.append(int(len(start_ind)))
         indexed_digin_list = list(
             zip(np.arange(len(dig_in_list)), dig_in_list))
@@ -214,6 +219,11 @@ else:
         dig_in_trials = []
         for n_i in range(num_dig_ins):
             start_ind = np.where(d_diff == n_i + 1)[0]
+            if len(start_ind) == 0:
+                print(f"== No deliveries detected for {dig_in_list[i]} ==")
+                print("== blech_clust is sad and can't work under these conditions ==")
+                print(f"== Please delete {dig_in_list[i]} and try again ==")
+                exit()
             dig_in_trials.append(int(len(start_ind)))
         dig_in_print_str = "A total of " + str(num_dig_ins)
         dig_in_present_bool = num_dig_ins > 0

--- a/blech_make_arrays.py
+++ b/blech_make_arrays.py
@@ -309,7 +309,7 @@ if __name__ == '__main__':
         hf5.create_group('/', 'spike_trains')
 
         # Pull out spike trains
-        for i, this_dig_in in enumerate(taste_starts_cutoff): 
+        for i, this_dig_in in zip(taste_digin_inds, taste_starts_cutoff): 
             print(f'Creating spike-trains for {dig_in_basename[i]}')
             create_spike_trains_for_digin(
                     taste_starts_cutoff,
@@ -324,7 +324,7 @@ if __name__ == '__main__':
         print('No sorted units found...NOT MAKING SPIKE TRAINS')
 
     # Separate out laser loop
-    for i, this_dig_in in enumerate(taste_starts_cutoff): 
+    for i, this_dig_in in zip(taste_digin_inds, taste_starts_cutoff): 
         print(f'Creating laser info for {dig_in_basename[i]}')
         create_laser_params_for_digin(
                 i,
@@ -372,7 +372,8 @@ if __name__ == '__main__':
             # And pull out emg data into this array
             for i in range(len(emg_pathname)):
                 data = hf5.get_node(emg_pathname[i])[:]
-                for j, this_taste_digin in enumerate(taste_starts_cutoff):
+                for j, this_taste_digin in \
+                        zip(taste_digin_inds, taste_starts_cutoff):
                     for k, this_start in enumerate(this_taste_digin):
                         trial_bounds = [
                                 int(this_start - durations[0]*sampling_rate_ms),

--- a/utils/read_file.py
+++ b/utils/read_file.py
@@ -4,6 +4,15 @@ import os
 import numpy as np
 import tqdm
 
+def check_digin_is_nonzero(dig_in_data):
+	"""
+	Check that digin is not empty (i.e. has some trials)
+	"""
+	if dig_in_data.sum() == 0:
+		return False	
+	else:
+		return True
+
 #todo: Separate functions for electrode, EMG, and dig-in channels
 def read_digins(hdf5_name, dig_in_int, dig_in_file_list): 
 	hf5 = tables.open_file(hdf5_name, 'r+')
@@ -15,9 +24,13 @@ def read_digins(hdf5_name, dig_in_int, dig_in_file_list):
 		print(f'Reading {dig_in_name}')
 		inputs = np.fromfile(dig_in_filename,
 					   dtype = np.dtype('uint16'))
-		dig_inputs = hf5.create_array(\
-				'/digital_in', dig_in_name, inputs)
-		hf5.flush()
+		if not check_digin_is_nonzero(inputs):
+			print(f'== No data in {dig_in_name}, not saving ==')
+			continue
+		else:
+			dig_inputs = hf5.create_array(\
+					'/digital_in', dig_in_name, inputs)
+			hf5.flush()
 	hf5.close()
 		
 #todo: Separate functions for electrode, EMG, and dig-in channels


### PR DESCRIPTION
Fix issues with handling dig-ins.
Changes made:
1-Zero pad dig_in names in HDF5 so they can be sorted correctly
2-Check for empty dig-ins and not save them during `blech_exp_info`
3-Rely explicitly on taste_digin_inds in `blech_make_arrays`