### PR TITLE
[HOTFIX] rename variable to correct name

### DIFF
--- a/blech_make_arrays.py
+++ b/blech_make_arrays.py
@@ -199,7 +199,7 @@ if __name__ == '__main__':
     if '/raw_emg' in hf5:
         raw_emg_electrodes = [x for x in hf5.get_node('/','raw_emg')]
     else:
-        raw_emg = []
+        raw_emg_electrodes = []
 
     all_electrodes = [raw_electrodes, raw_emg_electrodes] 
     all_electrodes = [x for y in all_electrodes for x in y]


### PR DESCRIPTION
Change name from `raw_emg` (unused variable) --> `raw_emg_electrodes`

Fix following error (from Christina):
![image](https://github.com/abuzarmahmood/blech_clust/assets/12436309/88aec9be-25cc-4b99-9850-f3b3710dd82f)
