### PR TITLE
README updates, and a minor tweak to dig_in import behavior to expand compatibility with different naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ conda activate blech_clust #activate blech_clust
 DIR=/path/to/raw/data/files  #save the path of the target Intan data to be sorted
 python blech_exp_info.py $DIR  # Generate metadata and electrode layout  
 ```
-Once you've started running the script, it will ask you to "fill in car groups". Go to the intan data folder, where you'll find a file named ```[...]_electrode_layout.csv```. Open this file in a spreadsheet editor, and fill in the ```CAR_group``` column. You should give all of the electrodes implanted in the same bundle the same identifier, and use different identifiers for different bundles (e.g. all electrodes from a bundle in right GC are called ```GC1```, and all electrodes from a bundle in left GC are called ```GC2```).
+Once you've started running the script, it will ask you to "fill in car groups". Go to the intan data folder, where you'll find a file named ```[...]_electrode_layout.csv```. Open this file in a spreadsheet editor, and fill in the ```CAR_group``` column. You should give all of the electrodes implanted in the same bundle the same identifier, and use different identifiers for different bundles (e.g. all electrodes from a bundle in right GC are called ```GC1```, and all electrodes from a bundle in left GC are called ```GC2```). Once you've edited the .csv, return to the terminal and type y/enter.
+Next, you'll be asked to provide indices for the intan digital inputs.
 
 ```
 bash blech_clust_pre.sh $DIR   # Perform steps up to spike extraction and UMAP  

--- a/README.md
+++ b/README.md
@@ -72,14 +72,18 @@ conda activate blech_clust #activate blech_clust
 DIR=/path/to/raw/data/files  #save the path of the target Intan data to be sorted
 python blech_exp_info.py $DIR  # Generate metadata and electrode layout  
 ```
-Once you've started running the script, it will ask you to "fill in car groups". Go to the intan data folder, where you'll find a file named ```[...]_electrode_layout.csv```. Open this file in a spreadsheet editor, and fill in the ```CAR_group``` column. You should give all of the electrodes implanted in the same bundle the same identifier, and use different identifiers for different bundles (e.g. all electrodes from a bundle in right GC are called ```GC1```, and all electrodes from a bundle in left GC are called ```GC2```). Once you've edited the .csv, return to the terminal and type y/enter.
-Next, you'll be asked to provide indices for the intan digital inputs. The script will have printed the available inputs immediately above, looking something like this:
+Once you've started running the script, it will ask you to "fill in car groups". Go to the intan data folder, where you'll find a file named ```[...]_electrode_layout.csv```. Open this file in a spreadsheet editor, and fill in the ```CAR_group``` column. You should give all of the electrodes implanted in the same bundle the same identifier, and use different identifiers for different bundles (e.g. all electrodes from a bundle in right GC are called ```GC1```, and all electrodes from a bundle in left GC are called ```GC2```). Once you've edited the .csv, return to the terminal and type ```y``` ```enter```.
+Next, you'll be asked to provide indices for the intan digital inputs. The script will have printed the available inputs immediately above, looking something like this, though the specific files may vary:
 ```
 (0, 'board-DIN-09.dat'),
 (1, 'board-DIN-11.dat'),
 (2, 'board-DIN-12.dat'),
 (3, 'board-DIN-13.dat')
 ```
+These are the files for the Intan digital inputs that blech_clust has detected in your data folder, which should correspond to the on/off times of each stimulus presentation. You can select as many or as few as you'd like to be included in later steps in the analysis; they don't impact initial spike-sorting. In this case, if we wanted to include DINs 11 and 13 but not 9 or 12, we would type ```1,3``` ```enter``` in the terminal, using the indices corresponding to the desired DINs.
+Next, you'll see this dialog: ```Tastes names used (IN ORDER, anything separated)  :: "x" to exit ::```, asking to provide taste names for each of your selected DINs. Supposing that DIN 11 was associated with DI H2O, and DIN 13 was 300mM sucrose, we would enter ```Water,Sucrose``` ```enter```, leaving off the molarity, which will be provided in the next step.
+That prompt (```Corresponding concs used (in M, IN ORDER, COMMA separated)  :: "x" to exit ::```) should immediately follow. This requires numeric inputs, so for our stimuli of DI H2O and 300mM sucrose, the appropriate input would be ```0,0.3``` ```enter```, giving the molarity of Water as 0, and converting mM to M in the sucrose concentration.
+The next prompt (```Enter palatability rankings used (anything separated), higher number = more palatable  :: "x" to exit ::```) asks for palatability rankings for the stimuli. This requires a numeric input > 0, but does not need to be integer, and accepts duplicate values (e.g. ```4,3,2,1``` is fine, ```0.4,0.3,0.2,0.1``` is also fine, even ```3,2,2,1``` is fine, but ```2,1,1,0``` is not). In our water/sucrose example, ```1,2``` ```enter``` would be an appropriate entry.
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ pip install -r neuRecommend/requirements.txt
 ![nomnoml (1)](https://github.com/abuzarmahmood/blech_clust/assets/12436309/3a44e1a7-af29-4f48-8aa1-427b3e983a81)
 
 
-### Example workflow
+### Workflow Walkthrough
 Open a terminal, and run:
 ```
 cd /path/to/blech_clust #make the blech_clust repository your working directory

--- a/README.md
+++ b/README.md
@@ -73,7 +73,14 @@ DIR=/path/to/raw/data/files  #save the path of the target Intan data to be sorte
 python blech_exp_info.py $DIR  # Generate metadata and electrode layout  
 ```
 Once you've started running the script, it will ask you to "fill in car groups". Go to the intan data folder, where you'll find a file named ```[...]_electrode_layout.csv```. Open this file in a spreadsheet editor, and fill in the ```CAR_group``` column. You should give all of the electrodes implanted in the same bundle the same identifier, and use different identifiers for different bundles (e.g. all electrodes from a bundle in right GC are called ```GC1```, and all electrodes from a bundle in left GC are called ```GC2```). Once you've edited the .csv, return to the terminal and type y/enter.
-Next, you'll be asked to provide indices for the intan digital inputs.
+Next, you'll be asked to provide indices for the intan digital inputs. The script will have printed the available inputs immediately above, looking something like this:
+```
+(0, 'board-DIN-09.dat'),
+(1, 'board-DIN-11.dat'),
+(2, 'board-DIN-12.dat'),
+(3, 'board-DIN-13.dat')
+```
+
 
 ```
 bash blech_clust_pre.sh $DIR   # Perform steps up to spike extraction and UMAP  

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Our final prompt (```::: Please enter any notes about the experiment.```) just a
 
 Once we've finished with ```blech_exp_info.py```, we'll want to continue on with either blech_clust.py or blech_clust_pre.sh. However, before we can run either thing, we'll need to set up a params file. First, copy blech_clust/params/_templates/sorting_params_template.json to blech_clust/params/sorting_params_template.json and update as needed.
 
+While you're there, you should also copy and adapt the other two params templates (`waveform_classifier_params.json` and `emg_params.json`), or you will probably be haunted by errors.
+
 ```
 bash blech_clust_pre.sh $DIR   # Perform steps up to spike extraction and UMAP  
 python blech_post_process.py   # Add sorted units to HDF5 (CLI or .CSV as input)  

--- a/README.md
+++ b/README.md
@@ -73,18 +73,20 @@ DIR=/path/to/raw/data/files  #save the path of the target Intan data to be sorte
 python blech_exp_info.py $DIR  # Generate metadata and electrode layout  
 ```
 Once you've started running the script, it will ask you to "fill in car groups". Go to the intan data folder, where you'll find a file named ```[...]_electrode_layout.csv```. Open this file in a spreadsheet editor, and fill in the ```CAR_group``` column. You should give all of the electrodes implanted in the same bundle the same identifier, and use different identifiers for different bundles (e.g. all electrodes from a bundle in right GC are called ```GC1```, and all electrodes from a bundle in left GC are called ```GC2```). Once you've edited the .csv, return to the terminal and type ```y``` ```enter```.
-Next, you'll be asked to provide indices for the intan digital inputs. The script will have printed the available inputs immediately above, looking something like this, though the specific files may vary:
+The script will then search your data folder for DIN files, and will print something like this, though the specific files may vary:
 ```
 (0, 'board-DIN-09.dat'),
 (1, 'board-DIN-11.dat'),
 (2, 'board-DIN-12.dat'),
 (3, 'board-DIN-13.dat')
 ```
-These are the files for the Intan digital inputs that blech_clust has detected in your data folder, which should correspond to the on/off times of each stimulus presentation. You can select as many or as few as you'd like to be included in later steps in the analysis; they don't impact initial spike-sorting. In this case, if we wanted to include DINs 11 and 13 but not 9 or 12, we would type ```1,3``` ```enter``` in the terminal, using the indices corresponding to the desired DINs.
-Next, you'll see this dialog: ```Tastes names used (IN ORDER, anything separated)  :: "x" to exit ::```, asking to provide taste names for each of your selected DINs. Supposing that DIN 11 was associated with DI H2O, and DIN 13 was 300mM sucrose, we would enter ```Water,Sucrose``` ```enter```, leaving off the molarity, which will be provided in the next step.
+These are the files for the Intan digital inputs that blech_clust has detected in your data folder, which should correspond to the on/off times of each stimulus presentation, and/or laser activations.
+You'll also be given this prompt: ```Taste dig_ins used (IN ORDER, anything separated)  :: "x" to exit ::```. You can select as many or as few as you'd like to be included in later steps in the analysis; they don't impact initial spike-sorting. In this case, if we wanted to include DINs 11 and 13 but not 09 or 12, we would type ```1,3``` ```enter``` in the terminal, using the indices corresponding to the desired DINs. If you have a DIN for laser activations, do not include that here; it will be requested at a later step.
+Next, you'll see this dialog: ```Tastes names used (IN ORDER, anything separated)  :: "x" to exit ::```, asking to provide taste names for each of your selected DINs. Supposing that DIN-11 was associated with DI H2O, and DIN-13 was 300mM sucrose, we would enter ```Water,Sucrose``` ```enter```, leaving off the molarity, which will be provided in the next step.
 That prompt (```Corresponding concs used (in M, IN ORDER, COMMA separated)  :: "x" to exit ::```) should immediately follow. This requires numeric inputs, so for our stimuli of DI H2O and 300mM sucrose, the appropriate input would be ```0,0.3``` ```enter```, giving the molarity of Water as 0, and converting mM to M in the sucrose concentration.
-The next prompt (```Enter palatability rankings used (anything separated), higher number = more palatable  :: "x" to exit ::```) asks for palatability rankings for the stimuli. This requires a numeric input > 0, but does not need to be integer, and accepts duplicate values (e.g. ```4,3,2,1``` is fine, ```0.4,0.3,0.2,0.1``` is also fine, even ```3,2,2,1``` is fine, but ```2,1,1,0``` is not). In our water/sucrose example, ```1,2``` ```enter``` would be an appropriate entry.
-
+The next prompt (```Enter palatability rankings used (anything separated), higher number = more palatable  :: "x" to exit ::```) asks for palatability rankings for the stimuli. This requires a numeric input > 0 and <= the number of stimuli, does not need to be integer, and accepts duplicate values (e.g. ```4,3,2,1``` is fine, ```0.4,0.3,0.2,0.1``` is also fine, even ```3,2,2,1``` is fine, but ```2,1,1,0``` is not, nor is ```5,4,3,2```). In our water/sucrose example, ```1,2``` ```enter``` would be an appropriate entry.
+The next prompt (```Laser dig_in index, <BLANK> for none::: "x" to exit ::```) asks for the index of the DIN corresponding to laser activations. If DIN-09 was the channel for the laser, for example, we would type ```0``` ```enter```, using the index corresponding with DIN-09. Alternatively, if we had no laser, we would just hit ```enter``` to proceed.
+Our final prompt (```::: Please enter any notes about the experiment.```) just asks for notes. Enter any pertinent comments, or just hit ```enter``` to finish running ```blech_exp_info.py```
 
 ```
 bash blech_clust_pre.sh $DIR   # Perform steps up to spike extraction and UMAP  

--- a/README.md
+++ b/README.md
@@ -88,8 +88,15 @@ The next prompt (```Enter palatability rankings used (anything separated), highe
 The next prompt (```Laser dig_in index, <BLANK> for none::: "x" to exit ::```) asks for the index of the DIN corresponding to laser activations. If DIN-09 was the channel for the laser, for example, we would type ```0``` ```enter```, using the index corresponding with DIN-09. Alternatively, if we had no laser, we would just hit ```enter``` to proceed.
 Our final prompt (```::: Please enter any notes about the experiment.```) just asks for notes. Enter any pertinent comments, or just hit ```enter``` to finish running ```blech_exp_info.py```
 
-Once we've finished with ```blech_exp_info.py```, we'll want to continue on with either blech_clust.py or blech_clust_pre.sh. However, before we can run either thing, we'll need to set up a params file. First, copy blech_clust/params/_templates/sorting_params_template.json to blech_clust/params/sorting_params_template.json and update as needed. Likely updates include: #######
-
+Once we've finished with ```blech_exp_info.py```, we'll want to continue on with either blech_clust.py or blech_clust_pre.sh. However, before we can run either thing, we'll need to set up a params file. First, copy blech_clust/params/_templates/sorting_params_template.json to blech_clust/params/sorting_params_template.json and update as needed. Likely updates include: 
+####### Need to make belch_clust compatible with IntanRead.R; currently 
+Traceback (most recent call last):
+  File "blech_clust.py", line 141, in <module>
+    dig_in_int = sorted([int(x) for x in dig_in_int])
+  File "blech_clust.py", line 141, in <listcomp>
+    dig_in_int = sorted([int(x) for x in dig_in_int])
+ValueError: invalid literal for int() with base 10: 'breakAlign_port2'
+So, blechclust is trying to import the DIN names as int, which is fine in the default convention, but not if you rename the DINs
 
 ```
 bash blech_clust_pre.sh $DIR   # Perform steps up to spike extraction and UMAP  

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ pip install -r neuRecommend/requirements.txt
 
 
 ### Workflow Walkthrough
+This section is being expanded, in progress.
 Open a terminal, and run:
 ```
 cd /path/to/blech_clust #make the blech_clust repository your working directory
@@ -88,15 +89,7 @@ The next prompt (```Enter palatability rankings used (anything separated), highe
 The next prompt (```Laser dig_in index, <BLANK> for none::: "x" to exit ::```) asks for the index of the DIN corresponding to laser activations. If DIN-09 was the channel for the laser, for example, we would type ```0``` ```enter```, using the index corresponding with DIN-09. Alternatively, if we had no laser, we would just hit ```enter``` to proceed.
 Our final prompt (```::: Please enter any notes about the experiment.```) just asks for notes. Enter any pertinent comments, or just hit ```enter``` to finish running ```blech_exp_info.py```
 
-Once we've finished with ```blech_exp_info.py```, we'll want to continue on with either blech_clust.py or blech_clust_pre.sh. However, before we can run either thing, we'll need to set up a params file. First, copy blech_clust/params/_templates/sorting_params_template.json to blech_clust/params/sorting_params_template.json and update as needed. Likely updates include: 
-####### Need to make belch_clust compatible with IntanRead.R; currently 
-Traceback (most recent call last):
-  File "blech_clust.py", line 141, in <module>
-    dig_in_int = sorted([int(x) for x in dig_in_int])
-  File "blech_clust.py", line 141, in <listcomp>
-    dig_in_int = sorted([int(x) for x in dig_in_int])
-ValueError: invalid literal for int() with base 10: 'breakAlign_port2'
-So, blechclust is trying to import the DIN names as int, which is fine in the default convention, but not if you rename the DINs
+Once we've finished with ```blech_exp_info.py```, we'll want to continue on with either blech_clust.py or blech_clust_pre.sh. However, before we can run either thing, we'll need to set up a params file. First, copy blech_clust/params/_templates/sorting_params_template.json to blech_clust/params/sorting_params_template.json and update as needed.
 
 ```
 bash blech_clust_pre.sh $DIR   # Perform steps up to spike extraction and UMAP  

--- a/README.md
+++ b/README.md
@@ -65,9 +65,16 @@ pip install -r neuRecommend/requirements.txt
 
 
 ### Example workflow
+Open a terminal, and run:
 ```
-DIR=/path/to/raw/data/files  
+cd /path/to/blech_clust #make the blech_clust repository your working directory
+conda activate blech_clust #activate blech_clust
+DIR=/path/to/raw/data/files  #save the path of the target Intan data to be sorted
 python blech_exp_info.py $DIR  # Generate metadata and electrode layout  
+```
+Once you've started running the script, it will ask you to "fill in car groups". Go to the intan data folder, where you'll find a file named ```[...]_electrode_layout.csv```. Open this file in a spreadsheet editor, and fill in the ```CAR_group``` column. You should give all of the electrodes implanted in the same bundle the same identifier, and use different identifiers for different bundles (e.g. all electrodes from a bundle in right GC are called ```GC1```, and all electrodes from a bundle in left GC are called ```GC2```).
+
+```
 bash blech_clust_pre.sh $DIR   # Perform steps up to spike extraction and UMAP  
 python blech_post_process.py   # Add sorted units to HDF5 (CLI or .CSV as input)  
 bash blech_clust_post.sh       # Perform steps up to PSTH generation

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ pip install -r neuRecommend/requirements.txt
 
 
 ### Workflow Walkthrough
-This section is being expanded, in progress.
+*This section is being expanded, in progress.*
+
 Open a terminal, and run:
 ```
 cd /path/to/blech_clust #make the blech_clust repository your working directory
@@ -82,11 +83,17 @@ The script will then search your data folder for DIN files, and will print somet
 (3, 'board-DIN-13.dat')
 ```
 These are the files for the Intan digital inputs that blech_clust has detected in your data folder, which should correspond to the on/off times of each stimulus presentation, and/or laser activations.
+
 You'll also be given this prompt: ```Taste dig_ins used (IN ORDER, anything separated)  :: "x" to exit ::```. You can select as many or as few as you'd like to be included in later steps in the analysis; they don't impact initial spike-sorting. In this case, if we wanted to include DINs 11 and 13 but not 09 or 12, we would type ```1,3``` ```enter``` in the terminal, using the indices corresponding to the desired DINs. If you have a DIN for laser activations, do not include that here; it will be requested at a later step.
+
 Next, you'll see this dialog: ```Tastes names used (IN ORDER, anything separated)  :: "x" to exit ::```, asking to provide taste names for each of your selected DINs. Supposing that DIN-11 was associated with DI H2O, and DIN-13 was 300mM sucrose, we would enter ```Water,Sucrose``` ```enter```, leaving off the molarity, which will be provided in the next step.
+
 That prompt (```Corresponding concs used (in M, IN ORDER, COMMA separated)  :: "x" to exit ::```) should immediately follow. This requires numeric inputs, so for our stimuli of DI H2O and 300mM sucrose, the appropriate input would be ```0,0.3``` ```enter```, giving the molarity of Water as 0, and converting mM to M in the sucrose concentration.
+
 The next prompt (```Enter palatability rankings used (anything separated), higher number = more palatable  :: "x" to exit ::```) asks for palatability rankings for the stimuli. This requires a numeric input > 0 and <= the number of stimuli, does not need to be integer, and accepts duplicate values (e.g. ```4,3,2,1``` is fine, ```0.4,0.3,0.2,0.1``` is also fine, even ```3,2,2,1``` is fine, but ```2,1,1,0``` is not, nor is ```5,4,3,2```). In our water/sucrose example, ```1,2``` ```enter``` would be an appropriate entry.
+
 The next prompt (```Laser dig_in index, <BLANK> for none::: "x" to exit ::```) asks for the index of the DIN corresponding to laser activations. If DIN-09 was the channel for the laser, for example, we would type ```0``` ```enter```, using the index corresponding with DIN-09. Alternatively, if we had no laser, we would just hit ```enter``` to proceed.
+
 Our final prompt (```::: Please enter any notes about the experiment.```) just asks for notes. Enter any pertinent comments, or just hit ```enter``` to finish running ```blech_exp_info.py```
 
 Once we've finished with ```blech_exp_info.py```, we'll want to continue on with either blech_clust.py or blech_clust_pre.sh. However, before we can run either thing, we'll need to set up a params file. First, copy blech_clust/params/_templates/sorting_params_template.json to blech_clust/params/sorting_params_template.json and update as needed.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ The next prompt (```Enter palatability rankings used (anything separated), highe
 The next prompt (```Laser dig_in index, <BLANK> for none::: "x" to exit ::```) asks for the index of the DIN corresponding to laser activations. If DIN-09 was the channel for the laser, for example, we would type ```0``` ```enter```, using the index corresponding with DIN-09. Alternatively, if we had no laser, we would just hit ```enter``` to proceed.
 Our final prompt (```::: Please enter any notes about the experiment.```) just asks for notes. Enter any pertinent comments, or just hit ```enter``` to finish running ```blech_exp_info.py```
 
+Once we've finished with ```blech_exp_info.py```, we'll want to continue on with either blech_clust.py or blech_clust_pre.sh. However, before we can run either thing, we'll need to set up a params file. First, copy blech_clust/params/_templates/sorting_params_template.json to blech_clust/params/sorting_params_template.json and update as needed. Likely updates include: #######
+
+
 ```
 bash blech_clust_pre.sh $DIR   # Perform steps up to spike extraction and UMAP  
 python blech_post_process.py   # Add sorted units to HDF5 (CLI or .CSV as input)  

--- a/blech_channel_profile.py
+++ b/blech_channel_profile.py
@@ -6,24 +6,19 @@ DIG_INs and AMP channels
 import argparse
 import glob
 import os
+import sys
 
-import easygui
 import numpy as np
 import pylab as plt
 from tqdm import tqdm
 
+from utils.blech_utils import imp_metadata
+
 # Get name of directory with the data files
 # Create argument parser
 parser = argparse.ArgumentParser(description = 'Plots DIG_INs and AMP files')
-parser.add_argument('dir_name',  help = 'Directory containing data files')
-args = parser.parse_args()
-
-if args.dir_name:
-    dir_path = args.dir_name
-    if dir_path[-1] != '/':
-        dir_path += '/'
-else:
-    dir_path = easygui.diropenbox(msg = 'Please select data directory')
+metadata_handler = imp_metadata(sys.argv)
+dir_path = metadata_handler.dir_name
 
 # Create plot dir
 plot_dir = os.path.join(dir_path, "channel_profile_plots")

--- a/blech_clust.py
+++ b/blech_clust.py
@@ -138,7 +138,7 @@ if file_type == ['one file per channel']:
     # Pull out the digital input channels used,
     # and convert them to integers
     dig_in_int = [x.split('-')[-1].split('.')[0] for x in dig_in_file_list]
-    dig_in_int = sorted([int(x) for x in dig_in_int])
+    dig_in_int = sorted([(x) for x in dig_in_int])
 
 elif file_type == ['one file per signal type']:
 

--- a/blech_clust.py
+++ b/blech_clust.py
@@ -243,12 +243,12 @@ dig_in_str = [f'{num}: {dig_in_map[num]}' for num in dig_in_map.keys()]
 
 plt.scatter(dig_in_markers[1], dig_in_markers[0], s=50, marker='|', c='k')
 # If there is a laser_dig_in, mark laser trials with axvline
-if laser_dig_in is not None:
+if laser_dig_in is not None and len(laser_dig_in) > 0:
     laser_markers = np.where(dig_in_markers[0] == laser_dig_in)[0]
     for marker in laser_markers:
         plt.axvline(dig_in_markers[1][marker], c='yellow', lw=2, alpha = 0.5,
                     zorder = -1)
-plt.yticks(np.arange(len(dig_in_str)), dig_in_str)
+plt.yticks(np.array(list(dig_in_map.keys())), dig_in_str)
 plt.title('Digital Inputs')
 plt.xlabel('Time (s)')
 plt.ylabel('Digital Input Channel')

--- a/blech_run_process.sh
+++ b/blech_run_process.sh
@@ -1,6 +1,24 @@
+#!/bin/bash
+
+# Function to show folder selection dialog using zenity
+choose_folder() {
+    zenity --file-selection --directory --title="Select data folder" 2>/dev/null
+}
+
 DIR=$1
+
+# Check if DIR exists and is a directory
+if [ ! -d "$DIR" ]; then
+    echo "Directory does not exist or was not provided. Please identify your data folder."
+    DIR=$(choose_folder)
+    if [ -z "$DIR" ]; then
+        echo "No folder selected. Exiting."
+        exit 1
+    fi
+fi
+
 echo "Processing $DIR"
 for i in {1..10}; do
     echo Retry $i
-    bash $DIR/temp/blech_process_parallel.sh
+    bash "$DIR/temp/blech_process_parallel.sh"
 done

--- a/blech_run_process.sh
+++ b/blech_run_process.sh
@@ -7,6 +7,14 @@ choose_folder() {
 
 DIR=$1
 
+# Check if the required file exists
+required_file="./params/waveform_classifier_params.json"
+if [ ! -f "$required_file" ]; then
+    echo "=== Waveform Classifier Params file not found. ==="
+    echo "==> Please copy [[ ./params/_templates/waveform_classifier_params.json ]] to [[ $required_file ]] and update as needed."
+    exit 1
+fi
+
 # Check if DIR exists and is a directory
 if [ ! -d "$DIR" ]; then
     echo "Directory does not exist or was not provided. Please identify your data folder."

--- a/utils/read_file.py
+++ b/utils/read_file.py
@@ -11,7 +11,7 @@ def read_digins(hdf5_name, dig_in_int, dig_in_file_list):
 	print('Reading dig-ins')
 	for i, (dig_int, dig_in_filename) in \
 			enumerate(zip(dig_in_int, dig_in_file_list)):
-		dig_in_name = f'dig_in_{dig_int:02d}'
+		dig_in_name = f'dig_in_{dig_int}'
 		print(f'Reading {dig_in_name}')
 		inputs = np.fromfile(dig_in_filename,
 					   dtype = np.dtype('uint16'))


### PR DESCRIPTION
I've been expanding the walkthrough in the readme. My additions could stand a proof-read, but otherwise straightforward.

Also, I have to modify the DIN.dat files for my behavior stuff, so I end up with a slightly different naming convention. Needed to modify the blech_clust.py and read_file.py to made them more compatible. Specifically, the scripts want to coerce part of the DIN filename to int-type, which doesn't work with my naming, so I just stopped it from doing that. As far as I can tell, the dig_in_int variable was only used by read_file.py to print out  a progress report as it imports files, so I don't think allowing it to accept non-int objects should be an issue.