### PR TITLE
203 misc blech post process tweaks and issues

### DIFF
--- a/blech_post_process.py
+++ b/blech_post_process.py
@@ -158,7 +158,7 @@ while (not auto_post_process) or (args.sort_file is not None):
         ##############################
         # Get clustering parameters from user
         continue_bool, n_clusters, n_iter, thresh, n_restarts = \
-                post_utils.get_clustering_params()
+                post_utils.get_clustering_params(this_sort_file_handler)
         if not continue_bool: continue
 
         # Make data array to be put through the GMM - 5 components: 

--- a/blech_post_process.py
+++ b/blech_post_process.py
@@ -87,9 +87,15 @@ post_utils.clean_memory_monitor_data()
 
 
 # Make the sorted_units group in the hdf5 file if it doesn't already exist
-if not '/sorted_units' in hf5:
+if '/sorted_units' in hf5:
+    overwrite_hf5 = input('Saved units detected; remove them? (y/[n]): ') or 'n'
+    if overwrite_hf5.lower() == 'y':
+        hf5.remove_node('/sorted_units', recursive=True)
+        hf5.create_group('/', 'sorted_units')
+else:
     hf5.create_group('/', 'sorted_units')
-
+    
+    
 ############################################################
 # Main Processing Loop 
 ############################################################

--- a/utils/blech_post_process_utils.py
+++ b/utils/blech_post_process_utils.py
@@ -34,6 +34,8 @@ class sort_file_handler():
             sort_table.sort_values(
                     ['len_cluster','Split'],
                     ascending=False, inplace=True)
+            if 'level_0' in sort_table.columns:
+                sort_table.drop(columns=['level_0'], inplace=True)
             sort_table.reset_index(inplace=True)
             sort_table['unit_saved'] = False
             self.sort_table = sort_table
@@ -160,7 +162,7 @@ def gen_select_cluster_plot(electrode_num, num_clusters, clusters):
             ax[cluster_num,0].axis('off')
             ax[cluster_num, 1].imshow(waveform_plot,aspect='auto');
             ax[cluster_num,1].axis('off')
-    fig.suptitle('Are these the neurons you want to select?')
+    fig.suptitle('Are these the neurons you want to select? Press q to exit plot')
     fig.tight_layout()
     plt.show()
 
@@ -216,12 +218,17 @@ def generate_cluster_plots(
     plt.tight_layout()
     plt.show()
 
-def get_clustering_params():
+def get_clustering_params(this_sort_file_handler):
     """
     Ask user for clustering parameters
     """
     # Get clustering parameters from user
-    n_clusters = int(input('Number of clusters (default=5): ') or "5")
+    if (this_sort_file_handler.sort_table is not None):
+        dat_row = this_sort_file_handler.current_row
+        n_clusters = int(input(f'Number of clusters (sort file={round(dat_row.Split)}): ') or dat_row.Split)
+    else:    
+        n_clusters = int(input('Number of clusters (default=5): ') or "5")
+    
     fields = [
             'Max iterations',
             'Convergence criterion',
@@ -982,7 +989,7 @@ class split_merge_signal:
                 check_func = lambda x: x in ['y','n'],
                 fail_response = 'Please enter (y/n)')
         if continue_bool:
-            if msg == 'y': 
+            if msg == 'y':
                 self.split = True
             elif msg == 'n': 
                 self.split = False
@@ -990,7 +997,7 @@ class split_merge_signal:
     def check_split_sort_file(self):
         if self.this_sort_file_handler.sort_table is not None:
             dat_row = self.this_sort_file_handler.current_row
-            if len(dat_row.Split) > 0:
+            if not (dat_row.Split == ''):
                 self.split=True
             else:
                 self.split=False

--- a/utils/blech_post_process_utils.py
+++ b/utils/blech_post_process_utils.py
@@ -225,7 +225,8 @@ def get_clustering_params(this_sort_file_handler):
     # Get clustering parameters from user
     if (this_sort_file_handler.sort_table is not None):
         dat_row = this_sort_file_handler.current_row
-        n_clusters = int(input(f'Number of clusters (sort file={round(dat_row.Split)}): ') or dat_row.Split)
+        split_val = int(re.findall('[0-9]+', str(dat_row.Split))[0])
+        n_clusters = int(input(f'Number of clusters (sort file={split_val})') or split_val)
     else:    
         n_clusters = int(input('Number of clusters (default=5): ') or "5")
     


### PR DESCRIPTION
Modifies various things about post_process, mainly making it more amenable to being run more than once.
-fixes an issue where the 'level_0 ' column of an input table would prevent re-runs
-allows (but does not force) importing of the # of desired splits from the input table. This includes flexible auto-detection of the split #, allowing for more permissive conventions
-allows (but defaults to not) wiping pre-existing saved units from the hdf5 file, helping prevent redundant entries.
-adds a bit of text to some plots prompting the user to 'press q to close plot'. I found myself forgetting that was how it worked, so figured a reminder wouldn't hurt, and would be helpful to people new to the workflow