### PR TITLE
176 blech run qa error, part 2: spike train plotting

### DIFF
--- a/utils/qa_utils/drift_check.py
+++ b/utils/qa_utils/drift_check.py
@@ -119,13 +119,18 @@ binned_spike_trains = [np.reshape(x, (x.shape[0], -1, bin_size)).sum(axis=2) for
 
 # Group by neuron across tastes
 plot_spike_trains = list(zip(*binned_spike_trains))
-zscore_binned_spike_trains = [zscore(x, axis=-1) for x in plot_spike_trains]
+
+# Z score the spike trains for each taste/neuron
+zscore_binned_spike_trains = []
+for UnitN in range(len(plot_spike_trains)):
+    zScoreTemp = [zscore(StimN, axis=-1) for StimN in plot_spike_trains[UnitN]]
+    zscore_binned_spike_trains.append(zScoreTemp)
 
 # Plot heatmaps of all tastes, both raw data and zscored
 fig, ax = plt.subplots(len(plot_spike_trains), 2, figsize=(10, 10))
 for i in range(len(plot_spike_trains)):
     ax[i, 0].imshow(plot_spike_trains[i], aspect='auto', interpolation='none')
-    ax[i, 1].imshow(zscore_binned_spike_trains[i], aspect='auto', interpolation='none')
+    ax[i, 1].imshow(zscore_binned_spike_trains[i], aspect='auto', interpolation='none') #MAR The new culprit
     ax[i, 0].set_title(f'Unit {i} Raw')
     ax[i, 1].set_title(f'Unit {i} Zscored')
     ax[i, 0].set_ylabel('Taste')
@@ -138,7 +143,7 @@ plt.close()
 fig, ax = plt.subplots(len(plot_spike_trains), 2, figsize=(10, 10))
 for i in range(len(plot_spike_trains)):
     ax[i, 0].plot(np.array(plot_spike_trains[i]).T, alpha=0.7)
-    ax[i, 1].plot(zscore_binned_spike_trains[i].T, alpha=0.7)
+    ax[i, 1].plot(zscore_binned_spike_trains[i].T, alpha=0.7)#MAR bet anything this is a poison pill also
     ax[i, 0].set_title(f'Unit {i} Raw')
     ax[i, 1].set_title(f'Unit {i} Zscored')
     ax[i, 0].set_ylabel('Taste')


### PR DESCRIPTION
When running blech_run_qa.sh with an uneven number of trials per stimulus, an error occurs during drift_check.py. drift_check.py attempts to plot spike train heatmaps for multiple stimuli, and in the process effectively concatenates the arrays of spike trains for multiple stimuli together, or tries to. If there are uneven numbers of stimulus trials, the spike train arrays are of different sizes, and the concatenation fails, throwing an error and breaking the script.

My fix was to identify stimuli with fewer trials (shorter spike train vectors) and pad them with NAs to equalize array size without otherwise altering the contents. This then allows the subsidiary arrays to be treated as equally-sized, facilitating calculations and plotting.

Additionally, slightly modified the heatmap plotting, such that data sets with large numbers of units (>10) are given extra height to accommodate the increased number of plots. Probably a fringe scenario, but figured it would be a harmless tweak.

Also added some comments to the script to describe the objects in question, for reference.