### PR TITLE
Add missing sampling_rate argument

### DIFF
--- a/blech_post_process.py
+++ b/blech_post_process.py
@@ -292,6 +292,7 @@ while (not auto_post_process) or (args.sort_file is not None):
         violations1, violations2,_,_ = post_utils.generate_datashader_plot(
                 unit_waveforms, 
                 unit_times,
+                sampling_rate,
                 title = 'Merged Unit',
                 )
 


### PR DESCRIPTION
Running the pipe as-is with merges included causes an error, because `generate_datashader_plot` is missing the `sampling_rate` argument